### PR TITLE
Camera

### DIFF
--- a/NanoEngine/Core/Camera/Camera2D.cs
+++ b/NanoEngine/Core/Camera/Camera2D.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using NanoEngine.ObjectTypes.Assets;
+using NanoEngine.Testing.Assets;
+
+namespace NanoEngine.Core.Camera
+{
+    public class Camera2D : ICamera2D
+    {
+        // Public getter to return the transform value of the camera        
+        public Matrix Transform { get; private set; }
+
+        // Holds the asset that the camera is focused on
+        private IAsset _focusedAsset;
+
+        // Holds the center point of the viewport
+        private static Vector2 _viewportCenter;
+        
+        public Camera2D(IAsset asset)
+        {
+            _focusedAsset = asset;
+            Update();
+        }
+
+        /// <summary>
+        /// Sets the size of the viewport
+        /// </summary>
+        /// <param name="viewport">The current size of the viewport</param>
+        public static void SetViewport(Viewport viewport)
+        {
+            _viewportCenter = new Vector2(viewport.Width / 2f, viewport.Height / 2f);
+        }
+
+        /// <summary>
+        /// Updates the camera location based on the assets position
+        /// </summary>
+        public void Update()
+        {
+            // Get the X and Y draw position of the camera
+            float posX = _focusedAsset.Position.X - _viewportCenter.X;
+            float posY = _focusedAsset.Position.Y - _viewportCenter.Y;
+
+            // If the x or y is less than 0 then set them to 0
+            if (posX < 0)
+                posX = 0;
+
+            if (posY < 0)
+                posY = 0;
+
+            // Create the new matrix for tha camera position
+            Transform = Matrix.CreateTranslation(
+                new Vector3(-posX, -posY, 0)
+            );
+        }
+
+        /// <summary>
+        /// Changes the focus of the camera to a new asset
+        /// </summary>
+        /// <param name="asset">The asset to be focused on</param>
+        public void ChangeFocusedAsset(IAsset asset)
+        {
+            _focusedAsset = asset;
+        }
+    }
+}

--- a/NanoEngine/Core/Camera/ICamera2D.cs
+++ b/NanoEngine/Core/Camera/ICamera2D.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Xna.Framework;
+using NanoEngine.ObjectTypes.Assets;
+
+namespace NanoEngine.Core.Camera
+{
+    public interface ICamera2D
+    {
+        // Public getter to return the transform value of the camera        
+        Matrix Transform { get; }
+
+        /// <summary>
+        /// Updates the camera location based on the assets position
+        /// </summary>
+        void Update();
+
+        /// <summary>
+        /// Changes the focus of the camera to a new asset
+        /// </summary>
+        /// <param name="asset">The asset to be focused on</param>
+        void ChangeFocusedAsset(IAsset asset);
+    }
+}

--- a/NanoEngine/Core/Managers/SceneManager.cs
+++ b/NanoEngine/Core/Managers/SceneManager.cs
@@ -9,6 +9,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using NanoEngine.Events;
+using NanoEngine.ObjectTypes.Control;
 
 namespace NanoEngine.Core.Managers
 {
@@ -59,6 +61,9 @@ namespace NanoEngine.Core.Managers
         {
             //Create new screen
             currentScreen = new T();
+
+            EventManager.Manager.AddDelegates(currentScreen);
+
             //load the screesn content
             LoadContent();
         }
@@ -100,6 +105,7 @@ namespace NanoEngine.Core.Managers
         {
             //Unloads content from the current screen
             currentScreen.UnloadContent();
+            EventManager.Manager.RemoveDelegates(currentScreen);
 
             //unload pause screen if not null
             if (pauseScreen != null)
@@ -143,7 +149,13 @@ namespace NanoEngine.Core.Managers
         {
             if (currentScreen != null)
             {
-                renderManager.StartDraw();
+                if (currentScreen.Camera2D != null)
+                    renderManager.StartDraw(
+                        SpriteSortMode.Deferred, BlendState.AlphaBlend, null,
+                        null, null, null, currentScreen.Camera2D.Transform
+                    );
+                else
+                    renderManager.StartDraw(SpriteSortMode.BackToFront, BlendState.AlphaBlend);
                 currentScreen.DrawScreen(renderManager);
                 renderManager.EndDraw();
             }

--- a/NanoEngine/Game1.cs
+++ b/NanoEngine/Game1.cs
@@ -6,6 +6,7 @@ using NanoEngine.Core.Managers;
 using NanoEngine.ObjectManagement.Managers;
 using NanoEngine.ObjectTypes.General;
 using System;
+using NanoEngine.Core.Camera;
 
 namespace NanoEngine
 {
@@ -44,8 +45,8 @@ namespace NanoEngine
             this.IsMouseVisible = true;
             ContentManagerLoad.Manager.Intinalise(Content);
 
-            graphics.PreferredBackBufferHeight = 1000;
-            graphics.ApplyChanges();
+
+            Camera2D.SetViewport(GraphicsDevice.Viewport);
 
             SceneManager.Manager.setStartScreen<TestGameScreen>();
 

--- a/NanoEngine/NanoEngine.csproj
+++ b/NanoEngine/NanoEngine.csproj
@@ -43,6 +43,8 @@
     <Compile Include="Collision\CollisionTypes\IAABB.cs" />
     <Compile Include="Collision\IQuadTree.cs" />
     <Compile Include="Collision\QuadTree.cs" />
+    <Compile Include="Core\Camera\Camera2D.cs" />
+    <Compile Include="Core\Camera\ICamera2D.cs" />
     <Compile Include="Core\Interfaces\IContentManagerLoad.cs" />
     <Compile Include="Core\Interfaces\IRenderManager.cs" />
     <Compile Include="Core\Interfaces\ISceneManager.cs" />

--- a/NanoEngine/ObjectManagement/Interfaces/ITileManager.cs
+++ b/NanoEngine/ObjectManagement/Interfaces/ITileManager.cs
@@ -26,7 +26,7 @@ namespace NanoEngine.ObjectManagement.Interfaces
         /// Loads a new tilemap ready to be drawn
         /// </summary>
         /// <param name="fileName">The name of the json tile map file</param>
-        void LoadTileMap(string fileName);
+        void LoadTileMap(string fileName, int mapHeight);
 
         /// <summary>
         /// Unloads all the content that the tile manager has created by

--- a/NanoEngine/ObjectManagement/Managers/AssetManager.cs
+++ b/NanoEngine/ObjectManagement/Managers/AssetManager.cs
@@ -161,7 +161,6 @@ namespace NanoEngine.ObjectManagement.Managers
             {
                 _quadTree.Insert(asset);
                 asset.Draw(rendermanager);
-                rendermanager.Draw(rendermanager.BlankTexture, asset.Bounds, Color.White);
             }
 
             foreach (IAsset asset in _assetDictionary.Values)

--- a/NanoEngine/ObjectManagement/Managers/TileManager.cs
+++ b/NanoEngine/ObjectManagement/Managers/TileManager.cs
@@ -60,7 +60,7 @@ namespace NanoEngine.ObjectManagement.Managers
         /// Loads a new tilemap ready to be drawn
         /// </summary>
         /// <param name="fileName">The name of the json tile map file</param>
-        public void LoadTileMap(string fileName)
+        public void LoadTileMap(string fileName, int mapHeight)
         {
             if(!fileName.Contains(".json"))
             {
@@ -74,7 +74,7 @@ namespace NanoEngine.ObjectManagement.Managers
             foreach (TileInformation tile in tileMap.tiles)
             {
                 ITile newTile = (ITile)Activator.CreateInstance(tiles[tile.spriteName]);
-                Rectangle location = new Rectangle(tile.x * 64, 1000 - tile.y * 64, tile.xsize, tile.ysize);
+                Rectangle location = new Rectangle(tile.x * 64, (64 * mapHeight) - tile.y * 64, tile.xsize, tile.ysize);
                 newTile.Initilise(location, new Vector2(tile.x, tile.y));
                 generatedTiles.Add(newTile);
             }

--- a/NanoEngine/ObjectTypes/General/GameScreen.cs
+++ b/NanoEngine/ObjectTypes/General/GameScreen.cs
@@ -6,12 +6,58 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using NanoEngine.Core.Camera;
+using NanoEngine.ObjectTypes.Assets;
 
 namespace NanoEngine.ObjectTypes.General
 {
     public abstract class GameScreen : IGameScreen
     {
         protected IAssetManager _assetManager = new AssetManager();
+
+        private IDictionary<string, ICamera2D> _cameras;
+
+        public ICamera2D Camera2D { get; private set; }
+
+        /// <summary>
+        /// Adds a camera to the level
+        /// </summary>
+        /// <param name="id">The id of the camera</param>
+        /// <param name="asset">The asset the camera should focus on</param>
+        protected void AddCamera(string id, IAsset asset)
+        {
+            // If this is the first camera then create the dict
+            if (_cameras == null)
+                _cameras = new Dictionary<string, ICamera2D>();
+
+            // Add the camera if one by that ID does not exsist
+            if (!_cameras.Keys.Contains(id))
+            {
+                _cameras.Add(id, new Camera2D(asset));
+                // If the current camera is null then set this camera to
+                // the main one
+                if (Camera2D == null)
+                    Camera2D = _cameras[id];
+            }
+        }
+
+        /// <summary>
+        /// Changes the current camera to a different one
+        /// </summary>
+        /// <param name="id">The id of the desired camera</param>
+        protected void ChangeCamera(string id)
+        {
+            // Attempt to change to the camera otherwise throw an error
+            try
+            {
+                Camera2D = _cameras[id];
+            }
+            catch (KeyNotFoundException err)
+            {
+                Console.WriteLine(err);
+                throw;
+            }
+        }
 
         /// <summary>
         /// Abstract method to force sub classes to implement it. It is used to load content to the screen 
@@ -53,6 +99,9 @@ namespace NanoEngine.ObjectTypes.General
         public void UpdateScreen()
         {
             _assetManager.UpdateAssets();
+            // If we have a camera then update it
+            if (Camera2D != null)
+                Camera2D.Update();
             Update();
         }
     }

--- a/NanoEngine/ObjectTypes/General/IGameScreen.cs
+++ b/NanoEngine/ObjectTypes/General/IGameScreen.cs
@@ -3,11 +3,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using NanoEngine.Core.Camera;
 
 namespace NanoEngine.ObjectTypes.General
 {
     public interface IGameScreen
     {
+        // Returns the current camera of the screen
+        ICamera2D Camera2D { get; }
+
         /// <summary>
         /// Method to load the staring content of the screen
         /// </summary>

--- a/NanoEngine/Testing/States/HorizontalState.cs
+++ b/NanoEngine/Testing/States/HorizontalState.cs
@@ -52,7 +52,7 @@ namespace NanoEngine.Testing.States
         {
             owner.ControledAsset.SetPosition(new Vector2(
                 owner.ControledAsset.Position.X,
-                owner.ControledAsset.Position.Y + 2 * _direction
+                owner.ControledAsset.Position.Y + 4 * _direction
             ));
         }
     }

--- a/NanoEngine/Testing/States/WalkingState.cs
+++ b/NanoEngine/Testing/States/WalkingState.cs
@@ -51,7 +51,7 @@ namespace NanoEngine.Testing.States
         public void Update(T owner)
         {
             owner.ControledAsset.SetPosition(new Vector2(
-                owner.ControledAsset.Position.X + 2 * _direction,
+                owner.ControledAsset.Position.X + 4 * _direction,
                 owner.ControledAsset.Position.Y
             ));
         }

--- a/NanoEngine/Testing/TestGameScreen.cs
+++ b/NanoEngine/Testing/TestGameScreen.cs
@@ -5,9 +5,13 @@ using System.Linq;
 using System.Text;
 using NanoEngine.Core.Interfaces;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
 using NanoEngine.Collision.CollisionTypes;
+using NanoEngine.Events.Args;
 using NanoEngine.ObjectManagement.Interfaces;
 using NanoEngine.ObjectManagement.Managers;
+using NanoEngine.ObjectTypes.Control;
+using NanoEngine.StateManagement.States;
 using NanoEngine.Testing;
 using NanoEngine.Testing.Tiles;
 using NanoEngine.Testing.Assets;
@@ -32,8 +36,7 @@ namespace NanoEngine
             tileManager = new TileManager();
             tileManager.AddTile<DirtTile>("dirt_tile");
             tileManager.AddTile<GrassTile>("grass_tile");
-            tileManager.LoadTileMap("TestLevel");
-
+            tileManager.LoadTileMap("TestLevel", 7);
 
         }
 

--- a/NanoEngine/Testing/TestGameScreen.cs
+++ b/NanoEngine/Testing/TestGameScreen.cs
@@ -18,7 +18,7 @@ using NanoEngine.Testing.Assets;
 
 namespace NanoEngine
 {
-    class TestGameScreen : GameScreen
+    class TestGameScreen : GameScreen, IKeyboardWanted
     {
         private ITileManager tileManager;
 
@@ -37,12 +37,31 @@ namespace NanoEngine
             tileManager.AddTile<DirtTile>("dirt_tile");
             tileManager.AddTile<GrassTile>("grass_tile");
             tileManager.LoadTileMap("TestLevel", 7);
+            AddCamera("player", _assetManager.RetriveAsset("player"));
+            AddCamera("zombie", _assetManager.RetriveAsset("zombie"));
 
         }
 
         protected override void Update()
         {
 
+        }
+
+        /// <summary>
+        /// Reciver for the keyboard change event
+        /// </summary>
+        /// <param name="sender">The handler that sent the event</param>
+        /// <param name="args">The aguemnts contained within the event</param>
+        public void OnKeyboardChange(object sender, NanoKeyboardEventArgs args)
+        {
+            if (args.TheKeys.ContainsKey(KeyStates.Pressed))
+            {
+                if (args.TheKeys[KeyStates.Pressed].Contains(Keys.D1))
+                    ChangeCamera("player");
+                else if (args.TheKeys[KeyStates.Pressed].Contains(Keys.D2))
+                    ChangeCamera("zom");
+            }
+                
         }
     }
 }


### PR DESCRIPTION
This PR implements a few things:

1. Primarily it adds a 2D camera to the engine which can be used on any screen which takes the the asset it will be focusing on as a parameter. It also has a ChangeFocusedAsset method which allows the user to swap the focused asset for another

2. The `IGameScreen` interface now has a Camera2D public variable allowing the scene manager to get the current camera. If it is null then the scenemanager will ignore it.

3. The `GameScreen` class has 2 new methods and 1 new variable
   1. Variable
      1. `_cameras` of type  `(IDictionary<string, ICamera2D>)` -> Dict to hold all the cameras the scene has
   2. Methods
      1. `AddCamera(string id, IAsset asset)` -> Creates and adds a camera to the screen and sets the main camera to that camera if it is currently null
      2. `ChangeCamera(string id)` -> Changes the current camera to one in the dictionary
4. the tile manager's `LoadTileMap` function now takes a parameter indicating the number of tiles on the Y axis there are.

The camera system can be seen in use on the test game screen.