### PR TITLE
Converts the EventManager from a singleton

### DIFF
--- a/NanoEngine/Core/Managers/SceneManager.cs
+++ b/NanoEngine/Core/Managers/SceneManager.cs
@@ -65,8 +65,6 @@ namespace NanoEngine.Core.Managers
             //Create new screen
             currentScreen = new T();
 
-            EventManager.Manager.AddDelegates(currentScreen);
-
             //load the screesn content
             LoadContent();
         }
@@ -89,6 +87,7 @@ namespace NanoEngine.Core.Managers
         /// </summary>
         protected void LoadContent()
         {
+            currentScreen.Initialise();
             //Loads content from the current screen
             currentScreen.LoadContent();
 
@@ -108,7 +107,6 @@ namespace NanoEngine.Core.Managers
         {
             //Unloads content from the current screen
             currentScreen.UnloadContent();
-            EventManager.Manager.RemoveDelegates(currentScreen);
 
             //unload pause screen if not null
             if (pauseScreen != null)

--- a/NanoEngine/Core/Managers/UpdateManager.cs
+++ b/NanoEngine/Core/Managers/UpdateManager.cs
@@ -60,7 +60,6 @@ namespace NanoEngine.Core.Managers
         public override void Update(GameTime gameTime)
         {
             this.gameTime = gameTime;
-            EventManager.Manager.Update();
             SceneManager.Manager.Update(this);
         }
 

--- a/NanoEngine/Events/EventManager.cs
+++ b/NanoEngine/Events/EventManager.cs
@@ -11,29 +11,18 @@ namespace NanoEngine.Events
     public class EventManager : IEventManager
     {
         //List to hold the the handlers
-        private static List<IHandler> handlers;
-
-        //Filed to hold instance to the handler
-        private static IEventManager manager;
-
-        /// <summary>
-        /// Getter to return the manager 
-        /// </summary>
-        public static IEventManager Manager
-        {
-            get { return manager ?? (manager = new EventManager()); }
-        }
+        private IList<IHandler> _handlers;
 
         /// <summary>
         /// Private constructor so it can only be created inside by the getter
         /// </summary>
-        private EventManager()
+        public EventManager()
         {
             //Initialise the instance variables
-            handlers = new List<IHandler>();
+            _handlers = new List<IHandler>();
             //Add handlers to list
-            handlers.Add(new MouseHandler());
-            handlers.Add(new KeyboardHandler());
+            _handlers.Add(new MouseHandler());
+            _handlers.Add(new KeyboardHandler());
         }
 
         /// <summary>
@@ -44,14 +33,14 @@ namespace NanoEngine.Events
         {
             if(obj is IMouseWanted)
             {
-                (handlers[0] as IMouseHandler).GetOnMouseDown += (obj as IMouseWanted).OnMouseDown;
-                (handlers[0] as IMouseHandler).GetOnMouseUp += (obj as IMouseWanted).OnMouseUp;
-                (handlers[0] as IMouseHandler).GetOnMouseMoved += (obj as IMouseWanted).OnMouseMoved;
+                (_handlers[0] as IMouseHandler).GetOnMouseDown += (obj as IMouseWanted).OnMouseDown;
+                (_handlers[0] as IMouseHandler).GetOnMouseUp += (obj as IMouseWanted).OnMouseUp;
+                (_handlers[0] as IMouseHandler).GetOnMouseMoved += (obj as IMouseWanted).OnMouseMoved;
             }
 
             if (obj is IKeyboardWanted)
             {
-                (handlers[1] as IKeyboardHandler).GetOnKeyboardChanged += (obj as IKeyboardWanted).OnKeyboardChange;
+                (_handlers[1] as IKeyboardHandler).GetOnKeyboardChanged += (obj as IKeyboardWanted).OnKeyboardChange;
             }
         }
 
@@ -63,14 +52,14 @@ namespace NanoEngine.Events
         {
             if (obj is IMouseWanted)
             {
-                (handlers[0] as IMouseHandler).GetOnMouseDown -= (obj as IMouseWanted).OnMouseDown;
-                (handlers[0] as IMouseHandler).GetOnMouseUp -= (obj as IMouseWanted).OnMouseUp;
-                (handlers[0] as IMouseHandler).GetOnMouseMoved -= (obj as IMouseWanted).OnMouseMoved;
+                (_handlers[0] as IMouseHandler).GetOnMouseDown -= (obj as IMouseWanted).OnMouseDown;
+                (_handlers[0] as IMouseHandler).GetOnMouseUp -= (obj as IMouseWanted).OnMouseUp;
+                (_handlers[0] as IMouseHandler).GetOnMouseMoved -= (obj as IMouseWanted).OnMouseMoved;
             }
 
             if (obj is IKeyboardWanted)
             {
-                (handlers[1] as IKeyboardHandler).GetOnKeyboardChanged -= (obj as IKeyboardWanted).OnKeyboardChange;
+                (_handlers[1] as IKeyboardHandler).GetOnKeyboardChanged -= (obj as IKeyboardWanted).OnKeyboardChange;
             }
         }
 
@@ -80,7 +69,7 @@ namespace NanoEngine.Events
         public void Update()
         {
             //Loop through the handlers and update them.
-            foreach(IHandler item in handlers)
+            foreach(IHandler item in _handlers)
             {
                 item.Update();
             }

--- a/NanoEngine/Menus/Menu.cs
+++ b/NanoEngine/Menus/Menu.cs
@@ -19,7 +19,7 @@ namespace NanoEngine.Menus
 
         private bool active;
 
-        private SoundEffect sound = ContentManagerLoad.Manager.LoadResource<SoundEffect>("Sounds/rollover3.wav");
+        private SoundEffect sound = ContentManagerLoad.Manager.LoadResource<SoundEffect>("Sounds/rollover3");
 
         public Menu(IList<IMenuItem> list, bool active)
         {
@@ -102,10 +102,8 @@ namespace NanoEngine.Menus
         {
             if (active)
             {
-                if (args.TheKeys[KeyStates.Pressed].Contains(Keys.PageDown))
-                    SoundManager.Manager.ChangeLoopedSoundVolume(-0.1F);
-                else if (args.TheKeys[KeyStates.Pressed].Contains(Keys.PageUp))
-                    SoundManager.Manager.ChangeLoopedSoundVolume(0.1F);
+                if (!args.TheKeys.Keys.Contains(KeyStates.Pressed))
+                    return;
 
                 SoundManager.Manager.PlaySound(sound);
                 if (args.TheKeys[KeyStates.Pressed].Contains(Keys.Up))

--- a/NanoEngine/ObjectManagement/Interfaces/IAiFactory.cs
+++ b/NanoEngine/ObjectManagement/Interfaces/IAiFactory.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using NanoEngine.Events.Interfaces;
 
 namespace NanoEngine.ObjectManagement.Interfaces
 {
@@ -14,7 +15,12 @@ namespace NanoEngine.ObjectManagement.Interfaces
         /// <typeparam name="T">Type of AI wanted</typeparam>
         /// <returns>The created AI</returns>
         IAiComponent CreateAi<T>() where T : IAiComponent, new();
-        
+
+        /// <summary>
+        /// Factory method to create an AI
+        /// </summary>
+        /// <param name="aiType">The type of ai we want to create</param>
+        /// <returns></returns>
         IAiComponent CreateAi(Type aiType);
     }
 }

--- a/NanoEngine/ObjectManagement/Managers/AiFactory.cs
+++ b/NanoEngine/ObjectManagement/Managers/AiFactory.cs
@@ -5,11 +5,19 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using NanoEngine.Events.Interfaces;
 
 namespace NanoEngine.ObjectManagement.Managers
 {
     public class AiFactory : IAiFactory
     {
+        private IEventManager _eventManager;
+
+        public AiFactory(IEventManager eventManager)
+        {
+            _eventManager = eventManager;
+        }
+
         /// <summary>
         /// Factory method to create an AI
         /// </summary>
@@ -20,16 +28,20 @@ namespace NanoEngine.ObjectManagement.Managers
             //Create new AI
             IAiComponent ai = new T();
             //Check if its certian things
-            EventManager.Manager.AddDelegates(ai);
-            //Add AI to list
+            _eventManager.AddDelegates(ai);
             //Return AI
             return ai;
         }
 
+        /// <summary>
+        /// Factory method to create an AI
+        /// </summary>
+        /// <param name="aiType">The type of ai we want to create</param>
+        /// <returns></returns>
         public IAiComponent CreateAi(Type aiType)
         {
             IAiComponent ai = (IAiComponent) Activator.CreateInstance(aiType);
-            EventManager.Manager.AddDelegates(ai);
+            _eventManager.AddDelegates(ai);
             return ai;
         }
     }

--- a/NanoEngine/ObjectManagement/Managers/AssetManager.cs
+++ b/NanoEngine/ObjectManagement/Managers/AssetManager.cs
@@ -12,6 +12,7 @@ using NanoEngine.ObjectManagement.Interfaces;
 using NanoEngine.ObjectTypes.Assets;
 using NanoEngine.Core.Interfaces;
 using NanoEngine.Core.Managers;
+using NanoEngine.Events.Interfaces;
 using NanoEngine.Physics;
 using OpenTK.Graphics.ES20;
 
@@ -35,13 +36,14 @@ namespace NanoEngine.ObjectManagement.Managers
 
         private IPhysicsManager _physicsManager;
 
-        public AssetManager()
+
+        public AssetManager(IEventManager eventManager)
         {
             _uid = 0;
             _assetDictionary = new Dictionary<string, IAsset>();
             _aiComponents = new Dictionary<string, IAiComponent>();
             _assetFactory = new AssetFactory();
-            _aiFactory = new AiFactory();
+            _aiFactory = new AiFactory(eventManager);
             _quadTree = new QuadTree(2, 5, RenderManager.RenderBounds);
             QuadTree.DrawQuadTrees = true;
             _collisionManager = new CollisionManager();
@@ -174,6 +176,7 @@ namespace NanoEngine.ObjectManagement.Managers
             {
                 if (aiComponent is IAssetmanagerNeeded)
                     (aiComponent as IAssetmanagerNeeded).AssetManager = this;
+                aiComponent.InitialiseAiComponent(aiComponent.ControledAsset);
             }
         }
 

--- a/NanoEngine/ObjectTypes/General/GameScreen.cs
+++ b/NanoEngine/ObjectTypes/General/GameScreen.cs
@@ -7,19 +7,23 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using NanoEngine.Core.Camera;
+using NanoEngine.Events;
+using NanoEngine.Events.Interfaces;
 using NanoEngine.ObjectTypes.Assets;
 
 namespace NanoEngine.ObjectTypes.General
 {
     public abstract class GameScreen : IGameScreen
     {
-        protected IAssetManager _assetManager = new AssetManager();
+        protected IAssetManager _assetManager;
 
         private IDictionary<string, ICamera2D> _cameras;
 
         public ICamera2D Camera2D { get; private set; }
 
         public double LevelTimer { get; private set; }
+
+        protected IEventManager EventManager;
 
         /// <summary>
         /// Adds a camera to the level
@@ -71,6 +75,9 @@ namespace NanoEngine.ObjectTypes.General
         /// </summary>
         public virtual void UnloadContent()
         {
+            EventManager = null;
+            _assetManager = null;
+            _cameras = null;
             ContentManagerLoad.Manager.UnloadAll();
         }
 
@@ -101,11 +108,21 @@ namespace NanoEngine.ObjectTypes.General
         public void UpdateScreen(IUpdateManager updateManager)
         {
             LevelTimer += updateManager.gameTime.ElapsedGameTime.TotalSeconds;
+            EventManager.Update();
             _assetManager.UpdateAssets();
             // If we have a camera then update it
             if (Camera2D != null)
                 Camera2D.Update();
             Update();
+        }
+
+        /// <summary>
+        /// Initialise's the screen
+        /// </summary>
+        public void Initialise()
+        {
+            EventManager = new EventManager();
+            _assetManager = new AssetManager(EventManager);
         }
     }
 }

--- a/NanoEngine/ObjectTypes/General/IGameScreen.cs
+++ b/NanoEngine/ObjectTypes/General/IGameScreen.cs
@@ -36,5 +36,10 @@ namespace NanoEngine.ObjectTypes.General
         /// </summary>
         /// <param name="updateManager">Provides a refrence to the updateManager.</param>
         void UpdateScreen(IUpdateManager updateManager);
+
+        /// <summary>
+        /// Initialise's the screen
+        /// </summary>
+        void Initialise();
     }
 }


### PR DESCRIPTION
The event manager which used to be a singleton meant that each screen had to share the same EventManager which is not great when you want to have multiple screens loaded (but not updating) at the same time. With this refactor the each screen now has its own event manager which is created within
the GameScreen class so it is accessable to the screens if needed. The Created event manager is injected into the AssetManager which injects it into the AIfactory so it can still register all events for the Ai