### PR TITLE
Scenemanager refactor

### DIFF
--- a/NanoEngine/Core/Interfaces/ISceneManager.cs
+++ b/NanoEngine/Core/Interfaces/ISceneManager.cs
@@ -9,12 +9,6 @@ namespace NanoEngine.Core.Interfaces
 {
     public interface ISceneManager
     {
-        /// <summary>
-        /// Changes the screen to the passed in screen
-        /// </summary>
-        /// <typeparam name="T">Screen of type IGameScreen</typeparam>
-        void ChangeScreen<T>() where T : IGameScreen, new();
-
         // Getter to retrive the current gamescreen
         IGameScreen CurrentGameScreen { get; }
 
@@ -22,16 +16,35 @@ namespace NanoEngine.Core.Interfaces
         Vector2 ScreenDimentions { get; }
 
         /// <summary>
-        /// Method that sets the games starting screen
+        /// Adds a screen to the scene manager
         /// </summary>
-        /// <typeparam name="T">The type of screen to be set</typeparam>
-        void setStartScreen<T>() where T : IGameScreen, new();
+        /// <typeparam name="T">The type of screen to add</typeparam>
+        /// <param name="name">The id of the screen</param>
+        void AddScreen<T>(string name) where T : IGameScreen, new();
 
         /// <summary>
-        /// Method that sets the pause screen of the game
+        /// Tells the scene manager to start updating the screen
         /// </summary>
-        /// <typeparam name="T">The object type of the screen</typeparam>
-        void setPauseScreen<T>() where T : IGameScreen, new();
+        /// <param name="name">The id of the screen to start updating</param>
+        void StartUpdatingScreen(string name);
+
+        /// <summary>
+        /// Tells the scenemnager to stop updating a screen
+        /// </summary>
+        /// <param name="name">The id of the screen to stop updating</param>
+        void StopUpdatingScreen(string name);
+
+        /// <summary>
+        /// Tells the scene manager to reload a screen
+        /// </summary>
+        /// <param name="name">The id of the screen to reload</param>
+        void ReloadScreen(string name);
+
+        /// <summary>
+        /// Tells the scenemanager to delete a scene
+        /// </summary>
+        /// <param name="name">The id of the scene to delete</param>
+        void DeleteScreen(string name);
 
         /// <summary>
         /// Method to draw the objects on the screen

--- a/NanoEngine/Events/Handlers/KeyboardHandler.cs
+++ b/NanoEngine/Events/Handlers/KeyboardHandler.cs
@@ -11,8 +11,6 @@ namespace NanoEngine.Events.Handlers
 {
     public class KeyboardHandler : IKeyboardHandler
     {
-        private static bool created = false;
-
         private event EventHandler<NanoKeyboardEventArgs> _onKeyboardChanged;
 
         public EventHandler<NanoKeyboardEventArgs> GetOnKeyboardChanged
@@ -26,7 +24,6 @@ namespace NanoEngine.Events.Handlers
 
         public KeyboardHandler()
         {
-            created = true;
         }
 
         /// <summary>

--- a/NanoEngine/Events/Handlers/MouseHandler.cs
+++ b/NanoEngine/Events/Handlers/MouseHandler.cs
@@ -11,8 +11,6 @@ namespace NanoEngine.Events.Handlers
 {
     public class MouseHandler : IMouseHandler
     {
-        private static bool created = false;
-
         //Two states to hold the current and the previous recored states
         MouseState currentMouseState, previousMouseState;
 
@@ -52,10 +50,7 @@ namespace NanoEngine.Events.Handlers
 
         public MouseHandler()
         {
-            if (created)
-                throw new SystemException("Sorry only one instance of the MouseHandler may be created");
-            else
-                created = true;
+
         }
 
         public void Update()

--- a/NanoEngine/Game1.cs
+++ b/NanoEngine/Game1.cs
@@ -52,7 +52,7 @@ namespace NanoEngine
             LevelLoader.AddLevelAsset<TestAsset, TestMind>(5, "player");
 
             NanoEngineInit.Initialize(GraphicsDevice, this, Content);
-            SceneManager.Manager.setStartScreen<TestGameScreen>();
+            SceneManager.Manager.AddScreen<TestGameScreen>("level1");
             
             base.Initialize();
         }

--- a/NanoEngine/ObjectTypes/General/GameScreen.cs
+++ b/NanoEngine/ObjectTypes/General/GameScreen.cs
@@ -78,7 +78,7 @@ namespace NanoEngine.ObjectTypes.General
             EventManager = null;
             _assetManager = null;
             _cameras = null;
-            ContentManagerLoad.Manager.UnloadAll();
+            Camera2D = null;
         }
 
         /// <summary>


### PR DESCRIPTION
Total overhall of the scenemanger

Previously the scenemanager only allowed for on screen to be draw/update at a time which is not optimal and it had specific methods that should not have been there such as setStartScreen and setPauseScreen. These methods have been deleted.

The new structure of the scenemanager is as follows:

**Properties**:

```cs
IDictonary<string, IGameScreen> _updatingScreens
```
All screens that are being updated 

```cs
IDictonary<string, IGameScreen> _availableScreens
```
All screens that are loaded but are not being updated
```cs
IList<IGameScreen> _screensMarkedForDeletion
```
All screens that Have been marked for deletion

**Methods**:
```cs
AddScreen<T>(string name)
```
Adds a screen to the available screens
```cs
StartUpdatingScreen(string name)
```
Starts updating the requested screen
```cs
StopUpdatingScreen(string name) 
```
Stops updating the requested screen
```cs
ReloadScreen(string name)
```
Reloads the requested screen
```cs
DeleteScreen(string name)
```
Marks a screen for deletion

The update and draw methods have stayed the same apart from now looping through the new _updatingScreens list and calling the draw/update methods.