### PR TITLE
Fix bug within the scenemanager

### DIFF
--- a/NanoEngine/Core/Managers/SceneManager.cs
+++ b/NanoEngine/Core/Managers/SceneManager.cs
@@ -100,7 +100,7 @@ namespace NanoEngine.Core.Managers
 
             // Add the screen from the avaliable screens to the updating screens
             _updatingScreens[name] = _avaliableScreens[name];
-            _updatingScreens.Remove(name);
+            _avaliableScreens.Remove(name);
         }
 
         /// <summary>


### PR DESCRIPTION
The StartUpdatingScreen within the scenemanager
was adding the screen to the updatingScreens dict
and then removing it straigt away instead of removing
it from the _avaliableScreens dict. This PR fixes that