### PR TITLE
Fix null error bug within the input handlers

### DIFF
--- a/NanoEngine/Events/Handlers/KeyboardHandler.cs
+++ b/NanoEngine/Events/Handlers/KeyboardHandler.cs
@@ -31,6 +31,10 @@ namespace NanoEngine.Events.Handlers
         /// </summary>
         public void Update()
         {
+            // If nothing is subscribed there is no point in checking
+            if (GetOnKeyboardChanged == null)
+                return;
+
             IDictionary<KeyStates, IList<Keys>> k = new Dictionary<KeyStates, IList<Keys>>();
             //Make the previous state equal to the current
             PrevKeyState = currentKeyState;

--- a/NanoEngine/Events/Handlers/MouseHandler.cs
+++ b/NanoEngine/Events/Handlers/MouseHandler.cs
@@ -55,6 +55,9 @@ namespace NanoEngine.Events.Handlers
 
         public void Update()
         {
+            // There is no point in checking the input if nothing is subsribed
+            if (onMouseDown == null)
+                return;
             //Set the previous state to the current state
             previousMouseState = currentMouseState;
             //Set the current state to the mouse state


### PR DESCRIPTION
When nothing was subsribed to the input handlers it
was throwing a null error since it was listening for
input events although nothing was subsribed. This fix
makes it so we only ever check for input if something
is subsribed this both fixes the bug and slightly
optimises out input handling