### PR TITLE
Fix level timer

### DIFF
--- a/NanoEngine/ObjectTypes/General/GameScreen.cs
+++ b/NanoEngine/ObjectTypes/General/GameScreen.cs
@@ -122,6 +122,7 @@ namespace NanoEngine.ObjectTypes.General
         /// </summary>
         public void Initialise()
         {
+            LevelTimer = 0;
             EventManager = new EventManager();
             _assetManager = new AssetManager(EventManager);
         }


### PR DESCRIPTION
The level timer was not being reset when a screen was
being "reloaded" this was a simple fix as the timer just
needed to be set to 0 on init