### PR TITLE
Adds a render filter to the engine

### DIFF
--- a/NanoEngine/Game1.cs
+++ b/NanoEngine/Game1.cs
@@ -7,6 +7,7 @@ using NanoEngine.ObjectManagement.Managers;
 using NanoEngine.ObjectTypes.General;
 using System;
 using NanoEngine.Core.Camera;
+using NanoEngine.ObjectManagement;
 using NanoEngine.Testing.Assets;
 using NanoEngine.Testing.Tiles;
 
@@ -50,6 +51,11 @@ namespace NanoEngine
             LevelLoader.AddLevelAsset<ChestAsset>(3);
             LevelLoader.AddLevelAsset<CoinAsset>(4);
             LevelLoader.AddLevelAsset<TestAsset, TestMind>(5, "player");
+
+            graphics.PreferredBackBufferWidth = 1980;
+            graphics.PreferredBackBufferHeight = 1080;
+            graphics.ApplyChanges();
+            RenderFilter.RenderOffset = new Vector2(1500, 200);
 
             NanoEngineInit.Initialize(GraphicsDevice, this, Content);
             SceneManager.Manager.AddScreen<TestGameScreen>("level1");

--- a/NanoEngine/NanoEngine.csproj
+++ b/NanoEngine/NanoEngine.csproj
@@ -85,6 +85,8 @@
     <Compile Include="Game1.cs" />
     <Compile Include="IAnimation.cs" />
     <Compile Include="IAssetmanagerNeeded.cs" />
+    <Compile Include="ObjectManagement\IRenderFilter.cs" />
+    <Compile Include="ObjectManagement\RenderFilter.cs" />
     <Compile Include="Physics\IPhysicsManager.cs" />
     <Compile Include="IState.cs" />
     <Compile Include="NanoEngineInit.cs" />

--- a/NanoEngine/NanoEngine.nuspec
+++ b/NanoEngine/NanoEngine.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>NanoEngine</id>
+    <version>0.0.49</version>
+    <title>NanoEngine</title>
+    <authors>GinoCubeddu</authors>
+    <owners>GinoCubeddu</owners>
+    <description>A simple 2d games engine</description>
+    <copyright>Copyright 2018</copyright>
+  </metadata>
+</package>

--- a/NanoEngine/ObjectManagement/IRenderFilter.cs
+++ b/NanoEngine/ObjectManagement/IRenderFilter.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NanoEngine.ObjectTypes.Assets;
+
+namespace NanoEngine.ObjectManagement
+{
+    public interface IRenderFilter
+    {
+        /// <summary>
+        /// Takes a dictonary of assets and filters out the ones that are not set in the render offset of
+        /// the render targets. If no render target
+        /// </summary>
+        /// <param name="assets">The dictonary of assets to filter</param>
+        /// <returns>A dictonary containing only the assets that are in the render zone(s)</returns>
+        IDictionary<string, IAsset> SortAssetsInRenderZone(IDictionary<string, IAsset> assets);
+
+        /// <summary>
+        /// Takes a dictonary of ai components and filters out the ones that are not set in the render offset of
+        /// the render targets. If no render target
+        /// </summary>
+        /// <param name="aiComponents">The dictonary of ai components to filter</param>
+        /// <returns>A dictonary containing only the assets that are in the render zone(s)</returns>
+        IDictionary<string, IAiComponent> SortAiInRenderZone(IDictionary<string, IAiComponent> aiComponents);
+
+        /// <summary>
+        /// Adds a render target to the RenderFilter
+        /// </summary>
+        /// <param name="asset">A render target for the filter to use</param>
+        void AddRenderTarget(IAsset asset);
+    }
+}

--- a/NanoEngine/ObjectManagement/Interfaces/IAssetManager.cs
+++ b/NanoEngine/ObjectManagement/Interfaces/IAssetManager.cs
@@ -175,6 +175,12 @@ namespace NanoEngine.ObjectManagement.Interfaces
         IAiComponent RetriveAssetAI(string uName);
 
         /// <summary>
+        /// Supplies the AssetManager with a render filter.
+        /// </summary>
+        /// <param name="renderFilter">The render filter to use</param>
+        void SupplyRenderFilter(IRenderFilter renderFilter);
+
+        /// <summary>
         /// Unloads and destroys all created assets and their minds
         /// </summary>
         void UnloadAssets();

--- a/NanoEngine/ObjectManagement/RenderFilter.cs
+++ b/NanoEngine/ObjectManagement/RenderFilter.cs
@@ -1,0 +1,133 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework.Graphics;
+using NanoEngine.ObjectTypes.Assets;
+
+namespace NanoEngine.ObjectManagement
+{
+    public class RenderFilter : IRenderFilter
+    {
+        public static Vector2 RenderOffset = new Vector2(GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width,
+                GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height);
+
+        public IList<IAsset> RenderTargets = new List<IAsset>();
+
+        /// <summary>
+        /// Takes a dictonary of assets and filters out the ones that are not set in the render offset of
+        /// the render targets. If no render target
+        /// </summary>
+        /// <param name="assets">The dictonary of assets to filter</param>
+        /// <returns>A dictonary containing only the assets that are in the render zone(s)</returns>
+        public IDictionary<string, IAsset> SortAssetsInRenderZone(IDictionary<string, IAsset> assets)
+        {
+            // If there are no render targets then no filter will be applied
+            if (RenderTargets.Count == 0)
+                return assets;
+
+            // Return a dictonary with the assets not in the render zone filtered out
+            return FilterDictonary<IAsset>(GetRenderableAssetNames(assets.Values.ToList()), assets);
+        }
+
+        /// <summary>
+        /// Takes a dictonary of ai components and filters out the ones that are not set in the render offset of
+        /// the render targets. If no render target
+        /// </summary>
+        /// <param name="aiComponents">The dictonary of ai components to filter</param>
+        /// <returns>A dictonary containing only the assets that are in the render zone(s)</returns>
+        public IDictionary<string, IAiComponent> SortAiInRenderZone(IDictionary<string, IAiComponent> aiComponents)
+        {
+            // If there are no render targets then no filter will be applied
+            if (RenderTargets.Count == 0)
+                return aiComponents;
+
+            // Get all the assets of the ai components
+            IList<IAsset> assets = new List<IAsset>();
+            foreach (IAiComponent aiComponent in aiComponents.Values)
+                assets.Add(aiComponent.ControledAsset);
+
+            // Return a dictonary with the assets not in the render zone filtered out
+            return FilterDictonary<IAiComponent>(GetRenderableAssetNames(assets), aiComponents);
+        }
+
+        /// <summary>
+        /// Adds a render target to the RenderFilter
+        /// </summary>
+        /// <param name="asset">A render target for the filter to use</param>
+        public void AddRenderTarget(IAsset asset)
+        {
+            RenderTargets.Add(asset);
+        }
+
+        /// <summary>
+        /// Creates a dictonary of type T as the value and a string as its key. The dictonary will
+        /// take the passed in names and return a dict with only the values of the names
+        /// </summary>
+        /// <typeparam name="T">The type of object</typeparam>
+        /// <param name="names">The list of names</param>
+        /// <param name="objectList">The original dict containing all objects of type T</param>
+        /// <returns></returns>
+        private IDictionary<string, T> FilterDictonary<T>(IList<string> names, IDictionary<string, T> objectList)
+        {
+            // Create a new dict of type T
+            IDictionary<string, T> renderableAssets = new Dictionary<string, T>();
+
+            // Loop through the passed in names
+            foreach (string renderableAssetName in names)
+                // If the name is within the passed in dict add it to the rendable assets
+                if (objectList.ContainsKey(renderableAssetName))
+                    renderableAssets[renderableAssetName] = objectList[renderableAssetName];
+
+            return renderableAssets;
+        }
+
+        /// <summary>
+        /// Loops through the passed in assets and returns all the names of the assets
+        /// that fall within the "RenderZones" calculated from the render targets and the render
+        /// offset
+        /// </summary>
+        /// <param name="assets">The list of assets to check</param>
+        /// <returns>the names of all the assets within the render zones</returns>
+        private IList<string> GetRenderableAssetNames(IList<IAsset> assets)
+        {
+            // Generate the renderOffsets for each renderAround target
+            IList<IList<int>> renderOffset = new List<IList<int>>();
+            for (int i = 0; i < RenderTargets.Count; i++)
+            {
+                // draw a box of points around the target
+                renderOffset.Add(new List<int>
+                {
+                    (int) (RenderTargets[i].Position.X + RenderOffset.X),
+                    (int) (RenderTargets[i].Position.X - RenderOffset.X),
+                    (int) (RenderTargets[i].Position.Y + RenderOffset.Y),
+                    (int) (RenderTargets[i].Position.Y - RenderOffset.Y)
+                });
+            }
+
+            // Create a list for all possible renderable assets
+            IList<string> renderableAssets = new List<string>();
+
+            // Loop through all the provided assets
+            foreach (IAsset asset in assets)
+            {
+                // Loop through all the offsets
+                foreach (IList<int> offset in renderOffset)
+                {
+                    // If the asset is within the offset box then we need to render it
+                    if (asset.Position.X < offset[0] && asset.Position.X > offset[1] && asset.Position.Y < offset[2] &&
+                        asset.Position.Y > offset[3])
+                    {
+                        // Add the asset to renderable assets and then break from the offset loop
+                        renderableAssets.Add(asset.UniqueName);
+                        break;
+                    }
+                }
+            }
+            // Return the renderable assets
+            return renderableAssets;
+        }
+    }
+}

--- a/NanoEngine/Physics/PhysicsManager.cs
+++ b/NanoEngine/Physics/PhysicsManager.cs
@@ -17,8 +17,9 @@ namespace NanoEngine.Physics
         {
             foreach (IAsset asset in assets)
             {
-                if (!(asset is PhysicsEntity pAsset))
+                if (!(asset is PhysicsEntity))
                     continue;
+                PhysicsEntity pAsset = ((PhysicsEntity)asset);
                 pAsset.Velocity *= pAsset.Damping;
                 pAsset.Velocity += pAsset.Acceleration;
                 pAsset.Position += pAsset.Velocity;

--- a/NanoEngine/Testing/TestGameScreen.cs
+++ b/NanoEngine/Testing/TestGameScreen.cs
@@ -9,6 +9,7 @@ using Microsoft.Xna.Framework.Input;
 using NanoEngine.Collision.CollisionTypes;
 using NanoEngine.Core.Managers;
 using NanoEngine.Events.Args;
+using NanoEngine.ObjectManagement;
 using NanoEngine.ObjectManagement.Interfaces;
 using NanoEngine.ObjectManagement.Managers;
 using NanoEngine.ObjectTypes.Control;
@@ -31,6 +32,9 @@ namespace NanoEngine
         {
             _assetManager.LoadLevel("Level2");
             _assetManager.CreateAsset<ChestAsset>(10, 10);
+            IRenderFilter filter = new RenderFilter();
+            filter.AddRenderTarget(_assetManager.RetriveAsset("player"));
+            _assetManager.SupplyRenderFilter(filter);
             AddCamera("player", _assetManager.RetriveAsset("player"));
             EventManager.AddDelegates(this);
         }


### PR DESCRIPTION
A render filter can be used to make the asset
manager only update/render in a certian area around the
RenderTarget

The asset managers render target insatnce is null until
the scene injects one into it as it is not the responsibilty
of the assetmanager to create it and define the render targets.