### PR TITLE
Quadtree optimisation

### DIFF
--- a/NanoEngine/Collision/QuadTree.cs
+++ b/NanoEngine/Collision/QuadTree.cs
@@ -211,7 +211,9 @@ namespace NanoEngine.Collision
 
             // Add all the assets from this quadrant
             foreach (IAsset pAsset in _assets)
-                if (pAsset.UniqueName != asset.UniqueName)
+                // Only return the result if the asset is not the same as itself and atleast one item is moveable
+                // No point in doing the test if both are not movable
+                if (pAsset.UniqueName != asset.UniqueName && (pAsset.IsMovable || asset.IsMovable))
                     possibleCollidables.Add(pAsset);
 
             return possibleCollidables;

--- a/NanoEngine/NanoEngine.nuspec
+++ b/NanoEngine/NanoEngine.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>NanoEngine</id>
-    <version>0.0.61</version>
+    <version>0.0.66</version>
     <title>NanoEngine</title>
     <authors>GinoCubeddu</authors>
     <owners>GinoCubeddu</owners>

--- a/NanoEngine/ObjectTypes/Assets/Entity.cs
+++ b/NanoEngine/ObjectTypes/Assets/Entity.cs
@@ -133,6 +133,7 @@ namespace NanoEngine.ObjectTypes.Assets
         //getter for the remove property
         private bool remove;
         public bool Remove { get { return remove; } }
+        public bool IsMovable { get; protected set; }
 
         /// <summary>
         /// Method to initalise the the entity

--- a/NanoEngine/ObjectTypes/Assets/IAsset.cs
+++ b/NanoEngine/ObjectTypes/Assets/IAsset.cs
@@ -31,6 +31,9 @@ namespace NanoEngine.ObjectTypes.Assets
         //getter for the remove variable
         bool Remove { get; }
 
+        // Getter to tell if the asset is moveable
+        bool IsMovable { get; }
+
         // Getter for the animation class that belongs to the asset
         IAnimation AssetAnimation { get; }
 


### PR DESCRIPTION
Optimises the quad tree by making it only return possible collisions of objects that can actualy collide,

(ie if both assets are imovable it is impossible for them to collide)