### PR TITLE
Further optimise collisions

### DIFF
--- a/NanoEngine/Collision/CollisionTypes/SAT.cs
+++ b/NanoEngine/Collision/CollisionTypes/SAT.cs
@@ -83,13 +83,13 @@ namespace NanoEngine.Collision.CollisionTypes
                     new NanoCollisionEventArgs()
                     {
                         CollidedWith = asset2,
-                        CollisionOverlap = -mtv,
+                        CollisionOverlap = mtv,
                         CollisionSide = CollisionSide.UNKNOWN
                     },
                     new NanoCollisionEventArgs()
                     {
                         CollidedWith = asset1,
-                        CollisionOverlap = mtv,
+                        CollisionOverlap = -mtv,
                         CollisionSide = CollisionSide.UNKNOWN
                     }
                 );

--- a/NanoEngine/Collision/IQuadTree.cs
+++ b/NanoEngine/Collision/IQuadTree.cs
@@ -17,6 +17,12 @@ namespace NanoEngine.Collision
         void Clear();
 
         /// <summary>
+        /// Returns the collidable lists for each qudrant that the tree has
+        /// </summary>
+        /// <returns>A list of lists containing the quadrants for each sector</returns>
+        IList<IList<Tuple<IAsset, IAiComponent>>> GetCollidablesByQuadrant();
+
+        /// <summary>
         /// Method will draw the quadtree to the scene if the DrawQuadTree
         /// paramater is set to true. Defaults to false
         /// </summary>
@@ -28,7 +34,7 @@ namespace NanoEngine.Collision
         /// and quadrant of the quad tree
         /// </summary>
         /// <param name="asset"></param>
-        void Insert(IAsset asset);
+        void Insert(Tuple<IAsset, IAiComponent> asset);
 
         /// <summary>
         /// Reteives all the possible assets that the passed in asset could
@@ -36,7 +42,7 @@ namespace NanoEngine.Collision
         /// </summary>
         /// <param name="asset"></param>
         /// <returns></returns>
-        IList<IAsset> RetriveCollidables(IAsset asset);
+        IList<Tuple<IAsset, IAiComponent>> RetriveCollidables(IAsset asset);
 
         /// <summary>
         /// Method to split the quadtree into another quad tree by creating

--- a/NanoEngine/Collision/Manager/CollisionManager.cs
+++ b/NanoEngine/Collision/Manager/CollisionManager.cs
@@ -102,6 +102,85 @@ namespace NanoEngine.Collision.Manager
         }
 
         /// <summary>
+        /// Checks to see if there is a collsion between an asset and a list
+        /// of assets
+        /// </summary>
+        /// <param name="asset">A tuple of an asset and its mind</param>
+        /// <param name="possibleCollisions">A list containingt tuples of assets and their minds</param>
+        public void CheckCollisionInQuadrant(
+            IList<Tuple<IAsset, IAiComponent>> possibleCollisions
+        )
+        {
+            // Create a new dict to hold the names of everything that has been checked so we
+            // dont run multiple of the same checks
+            IDictionary<string, IList<string>> checkedCollisions = new Dictionary<string, IList<string>>();
+
+            foreach (Tuple<IAsset, IAiComponent> possibleCollision in possibleCollisions)
+            {
+                checkedCollisions[possibleCollision.Item1.UniqueName] = new List<string>();
+            }
+
+            for (int i = 0; i < possibleCollisions.Count; i++)
+            {
+                for (int j = 0; j < possibleCollisions.Count; j++)
+                {
+                    // Continue if it is a self check
+                    if (i == j)
+                        continue;
+
+                    // Last 2 checks of broad phase
+                    // 1 - only do a check if at lease one object is "moveable"
+                    // 2 - only do the check if it has not already been done
+                    if ((!possibleCollisions[i].Item1.IsMovable && !possibleCollisions[j].Item1.IsMovable) ||
+                        checkedCollisions[possibleCollisions[i].Item1.UniqueName]
+                            .Contains(possibleCollisions[j].Item1.UniqueName))
+                        continue;
+
+                    // Inform asset to the asset it is about to be checked against
+                    checkedCollisions[possibleCollisions[j].Item1.UniqueName].Add(possibleCollisions[i].Item1.UniqueName);
+
+
+                    // default the collision to null
+                    Tuple<NanoCollisionEventArgs, NanoCollisionEventArgs> collision = null;
+
+                    // If both assets use aabb then we can check through AABB otherwise we NEED toc check
+                    // though SAT
+                    if (possibleCollisions[i].Item1 is IAABBColidable && possibleCollisions[j].Item1 is IAABBColidable)
+                        collision = _aabb.CheckCollision(possibleCollisions[i].Item1, possibleCollisions[j].Item1);
+                    else
+                    {
+                        // First do an AABB collision check to see if it is possible for a collision between
+                        // the objects this is done so we don't waste rss on SAT and do a hiracahy of collision
+                        //tests
+                        if (_aabb.CheckCanCollide(possibleCollisions[i].Item1, possibleCollisions[j].Item1))
+                        {
+                            collision = _sat.CheckCollision(possibleCollisions[i].Item1, possibleCollisions[j].Item1);
+
+                            // If there was a collision then set the collision side through aabb
+                            if (collision != null)
+                            {
+                                collision.Item1.CollisionSide = _aabb.GetCollisionSide(possibleCollisions[i].Item1, possibleCollisions[j].Item1);
+                                collision.Item2.CollisionSide = _aabb.GetCollisionSide(possibleCollisions[i].Item1, possibleCollisions[j].Item1);
+                            }
+                        }
+                    }
+
+                    // If the collision did not return null then send the collision responses
+                    if (collision != null)
+                    {
+                        (possibleCollisions[i].Item2 as ICollisionResponder)?.CollisionResponse(
+                            collision.Item1
+                        );
+                        (possibleCollisions[j].Item2 as ICollisionResponder)?.CollisionResponse(
+                            collision.Item2
+                        );
+                    }
+                }
+
+            }
+        }
+
+        /// <summary>
         /// Updates the collision manager against the passed in objects
         /// </summary>
         /// <param name="assets">All assets that are on screen</param>
@@ -124,18 +203,13 @@ namespace NanoEngine.Collision.Manager
         /// <param name="collidableAssets">All of the possible collidable assets</param>
         private void CheckForCollisions(IDictionary<string, Tuple<IAsset, IAiComponent>> collidableAssets)
         {
-            // Loop through each asset within the dict
-            foreach (Tuple<IAsset, IAiComponent> assetData in collidableAssets.Values)
+            // Get the collidables from each quadrant
+            IList<IList<Tuple<IAsset, IAiComponent>>> collidableQuads = _quadTree.GetCollidablesByQuadrant();
+
+            // Loop through the collidable lists the quadrants returned and check each list one at a time
+            foreach (IList<Tuple<IAsset, IAiComponent>> collidableQuad in collidableQuads)
             {
-                // Create a blacnk list to hold the possible collisions
-                IList<Tuple<IAsset, IAiComponent>> possibleCollisions = new List<Tuple<IAsset, IAiComponent>>();
-
-                // Check the quad tree for any possible collisions
-                foreach (IAsset asset in _quadTree.RetriveCollidables(assetData.Item1))
-                    possibleCollisions.Add(collidableAssets[asset.UniqueName]);
-
-                // Pass the generated list to the CheckCollision method
-                CheckCollision(assetData, possibleCollisions);
+                CheckCollisionInQuadrant(collidableQuad);
             }
         }
 
@@ -149,7 +223,7 @@ namespace NanoEngine.Collision.Manager
             _quadTree.Clear();
             // Loop through the passed in assets
             foreach (Tuple<IAsset, IAiComponent> assetData in collidableAssets.Values)
-                _quadTree.Insert(assetData.Item1);
+                _quadTree.Insert(assetData);
         }
 
         /// <summary>

--- a/NanoEngine/Collision/QuadTree.cs
+++ b/NanoEngine/Collision/QuadTree.cs
@@ -33,7 +33,7 @@ namespace NanoEngine.Collision
         private IQuadTree[] _nodes;
 
         // Holds all the assets that belong to this level/quadrant
-        private IList<IAsset> _assets;
+        private IList<Tuple<IAsset, IAiComponent>> _assets;
 
         // Tells the quad tree wether to draw or not
         public static bool DrawQuadTrees = false;
@@ -53,7 +53,7 @@ namespace NanoEngine.Collision
             _verticalCenterPoint = _bounds.X + (_bounds.Width / 2);
             _horizontalCenterPoint = _bounds.Y + (_bounds.Height / 2);
             _nodes = new IQuadTree[4];
-            _assets = new List<IAsset>();
+            _assets = new List<Tuple<IAsset, IAiComponent>>();
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace NanoEngine.Collision
         {
             // Delete the old list by overwriting it with a new one
             _assets = null;
-            _assets = new List<IAsset>();
+            _assets = new List<Tuple<IAsset, IAiComponent>>();
 
             // Loop through the sub quads and call the same method to clear
             // its assets then nullify the quadrant
@@ -120,9 +120,9 @@ namespace NanoEngine.Collision
         /// and quadrant of the quad tree
         /// </summary>
         /// <param name="asset"></param>
-        public void Insert(IAsset asset)
+        public void Insert(Tuple<IAsset, IAiComponent> asset)
         {
-            int index = GetAssetIndex(asset);
+            int index = GetAssetIndex(asset.Item1);
             // If the quadrant has sub quad trees we first want to attempt
             // to add it to one of those
             if (_nodes[0] != null && index != -1)
@@ -135,7 +135,7 @@ namespace NanoEngine.Collision
             {
                 // If the asset does not quite fit into one of the quadrants
                 // AND the quadtree has already been split
-                foreach (int i in GetQuadrantsIn(asset))
+                foreach (int i in GetQuadrantsIn(asset.Item1))
                     _nodes[i].Insert(asset);
                 return;
             }
@@ -151,19 +151,19 @@ namespace NanoEngine.Collision
 
                 // create a list to store the assets as we loop so we can remove
                 // them later
-                IList<IAsset> assetsToRemove = new List<IAsset>();
+                IList<Tuple<IAsset, IAiComponent>> assetsToRemove = new List<Tuple<IAsset, IAiComponent>>();
                 // loop through the objects
                 for (int i = 0; i < _assets.Count; i++)
                 {
                     // get the index of the object
-                    index = GetAssetIndex(_assets[i]);
+                    index = GetAssetIndex(_assets[i].Item1);
                     // if the object fits into a sub quad
                     if (index != -1)
                         // insert into specific quadrant if it fully fits
                         _nodes[index].Insert(_assets[i]);
                     else
                         // insert into the multiple quadrants it is in
-                        foreach (int j in GetQuadrantsIn(_assets[i]))
+                        foreach (int j in GetQuadrantsIn(_assets[i].Item1))
                             _nodes[j].Insert(_assets[i]);
 
                     // Add the asset for removal
@@ -171,7 +171,7 @@ namespace NanoEngine.Collision
                 }
 
                 // Loop through the assets and remove them from this level
-                foreach (IAsset asset1 in assetsToRemove)
+                foreach (Tuple<IAsset, IAiComponent> asset1 in assetsToRemove)
                 {
                     _assets.Remove(asset1);
                 }
@@ -184,10 +184,10 @@ namespace NanoEngine.Collision
         /// </summary>
         /// <param name="asset"></param>
         /// <returns></returns>
-        public IList<IAsset> RetriveCollidables(IAsset asset)
+        public IList<Tuple<IAsset, IAiComponent>> RetriveCollidables(IAsset asset)
         {
             // Create list to store the collidables of this quadrant
-            var possibleCollidables = new List<IAsset>();
+            var possibleCollidables = new List<Tuple<IAsset, IAiComponent>>();
 
             // Get the index of the asset we want to get the collidables for
             int index = GetAssetIndex(asset);
@@ -210,13 +210,39 @@ namespace NanoEngine.Collision
             }
 
             // Add all the assets from this quadrant
-            foreach (IAsset pAsset in _assets)
+            foreach (Tuple<IAsset, IAiComponent> pAsset in _assets)
                 // Only return the result if the asset is not the same as itself and atleast one item is moveable
                 // No point in doing the test if both are not movable
-                if (pAsset.UniqueName != asset.UniqueName && (pAsset.IsMovable || asset.IsMovable))
+                if (pAsset.Item1.UniqueName != asset.UniqueName)
                     possibleCollidables.Add(pAsset);
 
             return possibleCollidables;
+        }
+
+        /// <summary>
+        /// Returns the collidable lists for each qudrant that the tree has
+        /// </summary>
+        /// <returns>A list of lists containing the quadrants for each sector</returns>
+        public IList<IList<Tuple<IAsset, IAiComponent>>> GetCollidablesByQuadrant()
+        {
+            // Create the list for the current quadrant
+            IList<IList<Tuple<IAsset, IAiComponent>>> _quadrantList = new List<IList<Tuple<IAsset, IAiComponent>>>();
+
+            // Add the current assets to the list
+            _quadrantList.Add(_assets);
+
+            // if there are child nodes loop through them
+            if (_nodes[0] != null)
+            {
+                foreach (IQuadTree quadTree in _nodes)
+                {
+                    // Add the returned quadrants to the list
+                    ((List<IList<Tuple<IAsset, IAiComponent>>>)_quadrantList).AddRange(quadTree.GetCollidablesByQuadrant());
+                }
+            }
+
+            // Return the list for this and its child quadrants
+            return _quadrantList;
         }
 
         /// <summary>

--- a/NanoEngine/Content/Content.mgcb
+++ b/NanoEngine/Content/Content.mgcb
@@ -1,3 +1,4 @@
+
 #----------------------------- Global Properties ----------------------------#
 
 /outputDir:bin/WindowsGL

--- a/NanoEngine/Game1.cs
+++ b/NanoEngine/Game1.cs
@@ -12,6 +12,7 @@ using NanoEngine.Events;
 using NanoEngine.Events.Args;
 using NanoEngine.Events.Handlers;
 using NanoEngine.ObjectManagement;
+using NanoEngine.ObjectTypes.Assets;
 using NanoEngine.Testing;
 using NanoEngine.Testing.Assets;
 using NanoEngine.Testing.Tiles;
@@ -73,7 +74,7 @@ namespace NanoEngine
                 .LoadSound("soundTrack", "Desert Theme");
 
             ServiceLocator.Instance.RetriveService<ISceneManager>(DefaultNanoServices.SceneManager)
-                .AddScreen<TestScreen2>("level1");
+                .AddScreen<TestGameScreen>("level1");
 
             ServiceLocator.Instance.RetriveService<ISceneManager>(DefaultNanoServices.SceneManager)
                 .AddScreen<TestGameScreen1>("level2");

--- a/NanoEngine/Testing/Assets/Hex.cs
+++ b/NanoEngine/Testing/Assets/Hex.cs
@@ -22,6 +22,7 @@ namespace NanoEngine.Testing.Assets
             SetTexture(ServiceLocator.Instance.RetriveService<INanoContentManager>(DefaultNanoServices.ContentManager)
                 .LoadResource<Texture2D>("hex"));
 
+            IsMovable = true;
             IList<Vector2> points = new List<Vector2>();
             points.Add(new Vector2(-19, -32));
             points.Add(new Vector2(-37, -10));

--- a/NanoEngine/Testing/Assets/TestMind.cs
+++ b/NanoEngine/Testing/Assets/TestMind.cs
@@ -140,22 +140,23 @@ namespace NanoEngine.Testing.Assets
                 if (args.TheKeys[KeyStates.Pressed].Contains(Keys.D2))
                     controledEntity.Rotate(controledEntity.Position, 0.02f);
             }
-            if (args.TheKeys.ContainsKey(KeyStates.Pressed))
-                AssetManager.CreateAsset<CoinAsset, CoinMind>(new Vector2(ControledAsset.Position.X + 50, ControledAsset.Position.Y));
+            
 
         }
 
         public void CollisionResponse(NanoCollisionEventArgs response)
         {
             Console.WriteLine("PLAYER: " + response.CollisionSide);
-            controledEntity.SetPosition(controledEntity.Position + response.CollisionOverlap);
-            foreach (IList<Vector2> points in controledEntity.Points.Values)
-            {
-                for (int i = 0; i < points.Count; i++)
+            controledEntity.SetPosition(controledEntity.Position - response.CollisionOverlap);
+
+            if (controledEntity.Points != null)
+                foreach (IList<Vector2> points in controledEntity.Points.Values)
                 {
-                    points[i] += response.CollisionOverlap;
+                    for (int i = 0; i < points.Count; i++)
+                    {
+                        points[i] -= response.CollisionOverlap;
+                    }
                 }
-            }
             if (response.CollidedWith.UniqueName.ToLower().Contains("coin"))
                 response.CollidedWith.Despawn = true;
         }

--- a/NanoEngine/Testing/Tiles/GrassTile.cs
+++ b/NanoEngine/Testing/Tiles/GrassTile.cs
@@ -19,6 +19,7 @@ namespace NanoEngine.Testing.Tiles
         /// </summary>
         public override void Initilise()
         {
+            IsMovable = true;
             SetTexture(ServiceLocator.Instance.RetriveService<INanoContentManager>(DefaultNanoServices.ContentManager)
                 .LoadResource<Texture2D>("GrassMid"));
         }


### PR DESCRIPTION
The quadtree now has a method which will
return a list of lists that will be the collidable
assets in each quadrant.

The collision manager will now call this method and
loop through each quadrant of assets. when looping through
each asset within the quadrant and checking it against every other
we record what has been checked against each other so no duplicate
checks are made.

This 1 - halfs the number of checks we need to do and reduces the
amount of calls we need to make to the quad tree which would have had
to do multiple recursive searches per update now it only has to return
A list of quadrant collidables